### PR TITLE
Handle empty GA4 response with agent-friendly error instead of 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga4-connector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "npx prettier --write src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "npx prettier --write src/**/*.ts",
     "build": "tsc",
-    "generate-config": "HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH=./ GOOGLE_AUTH_CONFIG_FILEPATH=google_auth_config.json node dist/cli.js update --output configuration.json",
+    "generate-config": "HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH=./ GOOGLE_AUTH_CONFIG_FILEPATH=google_auth_config.json node dist/cli.js update --outfile configuration.json",
     "start": "HASURA_CONFIGURATION_DIRECTORY=./ GOOGLE_AUTH_CONFIG_FILEPATH=google_auth_config.json node dist/index.js serve --port 8200 --configuration configuration.json",
     "install-bin": "npm run build && npm install -g ."
   },


### PR DESCRIPTION
Improves error handling when GA4 API returns no data for a query by replacing generic 500 errors with more informative UnprocessableContent (422) responses.

### Changes:
- **Enhanced error handling**: When GA4 returns empty rows, now throws `UnprocessableContent` with detailed context instead of a generic error
- **User-friendly messaging**: Provides specific information about requested dimensions/metrics and actionable suggestions
- **Structured error response**: Includes metadata about the failed request to help users adjust their queries
- **Code cleanup**: Removed debug console.log statements
- **CLI fix**: Corrected `--output` flag to `--outfile` in package.json script
- **Version bump**: Updated package version to 0.1.1

### Error Response Example:
Instead of a 500 error, users now receive a 422 with:
```json
{
  "message": "No data available for the requested dimension/metric combination. Dimensions: [country, city], Metrics: [sessions]. Try using different dimensions or metrics, or adjust the date range and filters.",
  "details": {
    "requested_dimensions": ["country", "city"],
    "requested_metrics": ["sessions"],
    "suggestion": "Try different dimension/metric combinations or adjust filters"
  }
}